### PR TITLE
Fix defragmentation of Longmynd UDP packets not containing full BBHEADER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2] - 2022-11-13
+
+### Fixed
+
+- Defragmentation of Longmynd UDP packets carrying only part of the BBHEADER.
+
+## [0.1.1] - 2022-11-09
+
+### Fixed
+
+- Typo in README.
+
+## [0.1.0] - 2022-11-09
+
+### Added
+
+- Initial release.
+
+[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.1.2...HEAD
+[0.1.1]: https://github.com/daniestevez/dvb-gse/compare/v0.1.2...v0.1.2
+[0.1.1]: https://github.com/daniestevez/dvb-gse/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/daniestevez/dvb-gse/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dvb-gse"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "DVB-GSE (Digital Video Brodcast Generic Stream Encapsulation)"


### PR DESCRIPTION
During testing I have seen that sometimes Longmynd will output a
very small (a few bytes) UDP packet that only contains the beginning of
the BBHEADER of a BBFRAME. This matches what happens with the FT2232H
USB interface: the corresponding bulk transfer only carries a few
bytes.

Most likely this is caused by the bulk transfer being timed such it is
executed very shortly after the STV0910 begins to output a BBFRAME. In
this case the FT2232H FIFO would only contain the first few bytes of the
BBFRAME.

This fixes the problem by reading multiple UDP packets if necessary,
until enough data for a full BBHEADER has been collected. The BBHEADER
is then validated as usual.

I have tested that a ping -s 1450 -i 0.01 with IPv6 on a 1 Msym/s QPSK 1/2
normal FECFRAME no pilots link (which achieves occupancy of ~70%)
doesn't lose any packets after this change. There are no drops or decode
errors while streaming audio either.