### PR TITLE
add option to process single ISI in MIS-mode

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,6 +21,9 @@ struct Args {
     /// TUN interface name
     #[arg(long)]
     tun: String,
+    /// ISI to process in MIS mode (if this option is not specified, run in SIS mode)
+    #[arg(long)]
+    isi: Option<u8>,
 }
 
 fn try_join_multicast(socket: &UdpSocket, addr: &SocketAddr) -> Result<()> {
@@ -47,6 +50,7 @@ pub fn main() -> Result<()> {
     let socket = UdpSocket::bind(args.listen).context("failed to bind to UDP socket")?;
     try_join_multicast(&socket, &args.listen)?;
     let mut bbframe_defrag = BBFrameDefrag::new(socket);
+    bbframe_defrag.set_isi(args.isi);
     let mut gsepacket_defrag = GSEPacketDefrag::new();
     loop {
         let bbframe = bbframe_defrag


### PR DESCRIPTION
This adds a command line option to the CLI to run in MIS mode and process only of single ISI (indicated by the user). The corresponding changes in BBFrametDefrag have been implemented.

This closes #6.

Signed-off-by: Daniel Estévez <daniel@destevez.net>