### PR TITLE
gsepacket: add option to skip the total length check

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,9 @@ struct Args {
     /// ISI to process in MIS mode (if this option is not specified, run in SIS mode)
     #[arg(long)]
     isi: Option<u8>,
+    /// Skip checking the GSE total length field
+    #[arg(long)]
+    skip_total_length: bool,
 }
 
 fn try_join_multicast(socket: &UdpSocket, addr: &SocketAddr) -> Result<()> {
@@ -52,6 +55,7 @@ pub fn main() -> Result<()> {
     let mut bbframe_defrag = BBFrameDefrag::new(socket);
     bbframe_defrag.set_isi(args.isi);
     let mut gsepacket_defrag = GSEPacketDefrag::new();
+    gsepacket_defrag.set_skip_total_length_check(args.skip_total_length);
     loop {
         let bbframe = bbframe_defrag
             .get_bbframe()


### PR DESCRIPTION
Since some modulators put a wrong value in this field, this adds an option to the CLI and the GSE Packet defragmenter to skip the checking of the total length field.

This closes #11.

Signed-off-by: Daniel Estévez <daniel@destevez.net>