### PR TITLE
cli: use SO_REUSEADDR with multicast addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/.github"]
 [features]
 default = ["cli"]
 # Enables the CLI application.
-cli = ["anyhow", "clap", "env_logger", "tun-tap"]
+cli = ["anyhow", "clap", "env_logger", "libc", "tun-tap"]
 
 [dependencies]
 anyhow = { version = "1", features = ["std"], optional = true }
@@ -25,6 +25,7 @@ clap = { version = "4.0", features = ["derive"], optional = true }
 crc = "3.0"
 env_logger = { version = "0.10", optional = true }
 lazy_static = "1.4"
+libc = { version = "0.2", optional = true }
 log = "0.4"
 num_enum = "0.5"
 tun-tap = { version = "0.1", default-features = false, optional = true }


### PR DESCRIPTION
This sets the SO_REUSEADDR socket option when the address is a multicast address.

This feature has been requested in #7.

----

@F5OEO I've checked with `strace` that this calls
```
setsockopt(4, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
```
Can you check if this allows sharing the multicast address and port in your intended use case?