### PR TITLE
Fix handling of label re-use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2023-07-19
+
+### Fixed
+
+- Bug in handling of GSE packets with label re-use.
+
 ## [0.3.1] - 2023-05-23
 
 ### Fixed
@@ -48,7 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.3.1...HEAD
+[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/daniestevez/dvb-gse/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/daniestevez/dvb-gse/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/daniestevez/dvb-gse/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/daniestevez/dvb-gse/compare/v0.1.2...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dvb-gse"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "DVB-GSE (Digital Video Brodcast Generic Stream Encapsulation)"

--- a/src/gseheader.rs
+++ b/src/gseheader.rs
@@ -186,8 +186,13 @@ impl GSEHeader {
         if self.protocol_type.is_some() {
             len += 2;
         }
-        if let Some(label) = &self.label {
-            len += label.len();
+        // When the label type is re-use, the GSEHeader struct contains a label,
+        // but this was not transmitted over-the-air in the header, so we should
+        // not add the length of the label.
+        if !matches!(self.label_type, LabelType::ReUse) {
+            if let Some(label) = &self.label {
+                len += label.len();
+            }
         }
         len
     }


### PR DESCRIPTION
The label re-use option was not taken into account correctly when computing the length of the header. The length of the label borrowed from a preceding packet was being added when computing the length of the GSE header, but it should not be added.