### PR TITLE
Add support for additional input formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-09-29
+
+### Added
+
+- Support for receiving BBFRAMEs as complete UDP packets and in a TCP stream.
+
 ## [0.3.2] - 2023-07-19
 
 ### Fixed
@@ -54,7 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.3.2...HEAD
+[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/daniestevez/dvb-gse/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/daniestevez/dvb-gse/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/daniestevez/dvb-gse/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/daniestevez/dvb-gse/compare/v0.2.0...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dvb-gse"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "DVB-GSE (Digital Video Brodcast Generic Stream Encapsulation)"


### PR DESCRIPTION
This adds support for receiving BBFRAMEs either as complete frames in UDP packets (using jumbo frames) or in a TCP stream (the CLI application acts as server). For this, the bbframe and cli modules have been largely rewritten. Now it should be easier to add other input formats.