### PR TITLE
gsepacket: add check on slice bounds

### DIFF
--- a/src/gsepacket.rs
+++ b/src/gsepacket.rs
@@ -43,6 +43,10 @@ impl GSEPacket {
             log::error!("GSE Packet not fully contained inside bytes");
             return None;
         }
+        if total_len < header_len {
+            log::error!("GSE Packet total length is smaller than header length");
+            return None;
+        }
         let data = bytes.slice(header_len..total_len);
         Some(GSEPacket { header, data })
     }


### PR DESCRIPTION
By feeding random data to the GSE defragmenter I have found that it panics occasionally. It seems that it happens when the GSE total length is smaller than the header length, which causes the beginning index of the data slice to be larger than the end index.