### PR TITLE
fix build error with crc-3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2024-04-08
+
+### Fixed
+
+- Build error with crc-3.2.0.
+
 ## [0.6.0] - 2023-12-12
 
 ### Added
@@ -107,8 +113,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.6.0...HEAD
-[0.5.0]: https://github.com/daniestevez/dvb-gse/compare/v0.5.0...v0.6.0
+[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/daniestevez/dvb-gse/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/daniestevez/dvb-gse/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/daniestevez/dvb-gse/compare/v0.4.4...v0.5.0
 [0.4.4]: https://github.com/daniestevez/dvb-gse/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/daniestevez/dvb-gse/compare/v0.4.2...v0.4.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dvb-gse"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "DVB-GSE (Digital Video Brodcast Generic Stream Encapsulation)"

--- a/src/gsepacket.rs
+++ b/src/gsepacket.rs
@@ -125,7 +125,6 @@ pub struct GSEPacketDefrag {
     skip_total_length_check: bool,
 }
 
-#[derive(Clone)]
 struct Defrag {
     total_length: usize,
     protocol_type: u16,


### PR DESCRIPTION
In crc-3.2.0 the crc::Digest struct that we use is no longer Clone. This is because it has gained an extra type parameter Implementation that defaults to Table<1>, which does not implement Clone.

This breaks dvb-gse, because the struct Defrag, which includes a crc::Digest, was deriving Clone.

Since Defrag is a private struct and the fact that it is Clone is not exposed in the API (it is only included in GSEPacketDefrag, which is not Clone), we can simply remove the derive Clone from Defrag to fix this problem.