### PR TITLE
Allow concurrent TCP clients

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,13 @@ jobs:
     name: Default features
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Format
       run: cargo fmt --all -- --check
     - name: Clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
     - name: Doc
-      run: cargo doc
+      run: RUSTDOCFLAGS="-D warnings" cargo doc
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -26,13 +26,13 @@ jobs:
     name: No features
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Format
       run: cargo fmt --all -- --check
     - name: Clippy
-      run: cargo clippy --no-default-features -- -D warnings
+      run: cargo clippy --all-targets --no-default-features -- -D warnings
     - name: Doc
-      run: cargo doc
+      run: RUSTDOCFLAGS="-D warnings" cargo doc
     - name: Build
       run: cargo build --no-default-features --verbose
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2024-05-01
+
+### Added
+
+- Support for handling concurrent TCP connections with `--input TCP`.
+
+### Changed
+
+- Log BBFRAMEs and GSE packets in hex format.
+
 ## [0.6.1] - 2024-04-08
 
 ### Fixed
@@ -113,7 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.6.1...HEAD
+[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/daniestevez/dvb-gse/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/daniestevez/dvb-gse/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/daniestevez/dvb-gse/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/daniestevez/dvb-gse/compare/v0.4.4...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dvb-gse"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "DVB-GSE (Digital Video Brodcast Generic Stream Encapsulation)"
@@ -21,9 +21,9 @@ cli = ["anyhow", "clap", "env_logger", "libc", "tun-tap"]
 anyhow = { version = "1", features = ["std"], optional = true }
 bitvec = "1"
 bytes = "1.2"
-clap = { version = "4.0", features = ["derive"], optional = true }
-crc = "3.0"
-env_logger = { version = "0.10", optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
+crc = "3"
+env_logger = { version = "0.11", optional = true }
 faster-hex = "0.9"
 lazy_static = "1.4"
 libc = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.2"
 clap = { version = "4.0", features = ["derive"], optional = true }
 crc = "3.0"
 env_logger = { version = "0.10", optional = true }
+faster-hex = "0.9"
 lazy_static = "1.4"
 libc = { version = "0.2", optional = true }
 log = "0.4"

--- a/src/bbframe.rs
+++ b/src/bbframe.rs
@@ -363,7 +363,7 @@ impl<R: RecvFragment> BBFrameReceiver for BBFrameDefrag<R> {
                 self.recv()?;
             }
             let bbframe = Bytes::copy_from_slice(&self.buffer[..bbframe_len]);
-            log::trace!("completed BBFRAME {:?}", bbframe);
+            log::trace!("completed BBFRAME {}", faster_hex::hex_string(&bbframe));
             return Ok(bbframe);
         }
     }
@@ -476,7 +476,7 @@ impl<R: RecvBBFrame> BBFrameReceiver for BBFrameRecv<R> {
             ));
         }
         let bbframe = Bytes::copy_from_slice(&self.buffer[..bbframe_len]);
-        log::trace!("completed BBFRAME {:?}", bbframe);
+        log::trace!("completed BBFRAME {}", faster_hex::hex_string(&bbframe));
         Ok(bbframe)
     }
 }
@@ -548,7 +548,7 @@ impl<R: RecvStream> BBFrameReceiver for BBFrameStream<R> {
         self.recv_stream
             .recv_stream(&mut self.buffer[BBHeader::LEN..bbframe_len])?;
         let bbframe = Bytes::copy_from_slice(&self.buffer[..bbframe_len]);
-        log::trace!("completed BBFRAME {:?}", bbframe);
+        log::trace!("completed BBFRAME {}", faster_hex::hex_string(&bbframe));
         Ok(bbframe)
     }
 }

--- a/src/bbframe.rs
+++ b/src/bbframe.rs
@@ -676,7 +676,7 @@ mod test {
          30 31 32 33 34 35 36 37"
     );
 
-    static MULTIPLE_FRAGMENTS: [&'static [u8]; 3] = [&FRAGMENT0, &FRAGMENT1, &FRAGMENT2];
+    static MULTIPLE_FRAGMENTS: [&[u8]; 3] = [&FRAGMENT0, &FRAGMENT1, &FRAGMENT2];
 
     #[test]
     fn single_fragment_defrag() {
@@ -861,7 +861,7 @@ mod proptests {
             // twice in order to flush a partial BBHEADER left
             // by the garbage.
             assert!(times_called.get() <= garbage_data.len() + 2);
-            if times_called.get() >= garbage_data.len() + 1 {
+            if times_called.get() > garbage_data.len() {
                 assert_eq!(bbframe, Bytes::from_static(&SINGLE_FRAGMENT));
             }
         }
@@ -894,7 +894,7 @@ mod proptests {
             while times_called.get() <= garbage_data.len() {
                 if let Ok(bbframe) = recv.get_bbframe() {
                     assert!(times_called.get() <= garbage_data.len() + 1);
-                    if times_called.get() >= garbage_data.len() + 1 {
+                    if times_called.get() > garbage_data.len() {
                         assert_eq!(bbframe, Bytes::from_static(&SINGLE_FRAGMENT));
                     }
                 }

--- a/src/gseheader.rs
+++ b/src/gseheader.rs
@@ -539,7 +539,8 @@ mod proptests {
                 header.protocol_type();
                 if let Some(label) = header.label() {
                     label.as_slice();
-                    assert_eq!(label.is_empty(), label.len() == 0);
+                    let len = label.len();
+                    assert_eq!(label.is_empty(), len == 0);
                 }
                 assert!(header.len() >= 3);
                 assert!(!header.is_empty());

--- a/src/gsepacket.rs
+++ b/src/gsepacket.rs
@@ -379,7 +379,7 @@ mod proptests {
         fn defrag_garbage(garbage_bbframes in garbage()) {
             let mut defrag = GSEPacketDefrag::new();
             for bbframe in &garbage_bbframes {
-                if let Ok(pdus) = defrag.defragment(&bbframe) {
+                if let Ok(pdus) = defrag.defragment(bbframe) {
                     for pdu in pdus {
                         pdu.data();
                         pdu.protocol_type();

--- a/src/gsepacket.rs
+++ b/src/gsepacket.rs
@@ -77,7 +77,10 @@ impl GSEPacket {
         Ok(std::iter::from_fn(move || {
             if let Some(packet) = GSEPacket::from_bytes(&remain, label.as_ref()) {
                 log::debug!("extracted GSE Packet with header {}", packet.header());
-                log::trace!("GSE Packet data field {:?}", packet.data());
+                log::trace!(
+                    "GSE Packet data field {}",
+                    faster_hex::hex_string(packet.data())
+                );
                 remain = remain.slice(packet.len()..);
                 if let Some(l) = packet.header.label() {
                     label = Some(l.clone());


### PR DESCRIPTION
This adds handling of concurrent clients with `--input TCP`, by spawning one thread per client and using an additional thread for the TUN device.