### PR TITLE
Remove git-version crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2025-03-13
+
+### Fixed
+
+- Removed git-version, as it made impossible to install the crate from crates.io.
+
 ## [0.7.1] - 2025-03-13
 
 ### Added
@@ -135,8 +141,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.7.1...HEAD
-[0.7.1]: https://github.com/daniestevez/dvb-gse/compare/v0.7.1...v0.7.1
+[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/daniestevez/dvb-gse/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/daniestevez/dvb-gse/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/daniestevez/dvb-gse/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/daniestevez/dvb-gse/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/daniestevez/dvb-gse/compare/v0.6.0...v0.6.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dvb-gse"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "DVB-GSE (Digital Video Brodcast Generic Stream Encapsulation)"
@@ -25,7 +25,6 @@ clap = { version = "4", features = ["derive"], optional = true }
 crc = "3"
 env_logger = { version = "0.11", optional = true }
 faster-hex = "0.10"
-git-version = "0.3.9"
 lazy_static = "1.4"
 libc = { version = "0.2", optional = true }
 log = "0.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -203,11 +203,7 @@ pub fn main() -> Result<()> {
     let args = Args::parse();
     let mut tun = tun_tap::Iface::without_packet_info(&args.tun, tun_tap::Mode::Tun)
         .context("failed to open TUN device")?;
-    log::info!(
-        "dvb-gse v{} (git {}) started",
-        env!("CARGO_PKG_VERSION"),
-        git_version::git_version!()
-    );
+    log::info!("dvb-gse v{} started", env!("CARGO_PKG_VERSION"));
     let stats = Arc::new(Mutex::new(Stats::default()));
     if args.stats_interval != 0.0 {
         std::thread::spawn({


### PR DESCRIPTION
This made it impossible to install the crate from crates.io, since the .git directory is not included in the package. For the time being, git-version is removed until having a good way to embed git version info in the carg package.