### PR TITLE
Add support for label filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ as server. The following rules need to be followed.
 If an error occurrs or the client closes the connection, the CLI application
 will continue to listen for new clients.
 
+## Label filtering
+
+The `dvb-gse` application supports filtering by GSE label the PDUs that are
+written to the TUN interface. The `--allow-broadcast` and `--allow-label`
+arguments are used to define what labels are allowed. If none of these arguments
+is used, then all GSE PDUs are written to the TUN. If some of these arguments
+are used, then GSE PDUs are dropped by default unless explicitly allowed by one
+of the arguments used.
+
 ## GSE-HEM
 
 GSE-HEM is auto-detected by using the TS/GS field in the BBHEADER (both

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@
 
 use crate::{
     bbframe::{BBFrameDefrag, BBFrameReceiver, BBFrameRecv, BBFrameStream},
+    gseheader::Label,
     gsepacket::{GSEPacketDefrag, PDU},
 };
 use anyhow::{Context, Result};
@@ -20,31 +21,72 @@ use std::{
     time::Duration,
 };
 
-/// Receive DVB-GSE and send PDUs into a TUN device
+/// Receive DVB-GSE and send PDUs into a TUN device.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// IP address and port to listen on to receive DVB-S2 BBFRAMEs
+    /// IP address and port to listen on to receive DVB-S2 BBFRAMEs.
     #[arg(long)]
     listen: SocketAddr,
-    /// TUN interface name
+    /// TUN interface name.
     #[arg(long)]
     tun: String,
-    /// Input format: "UDP fragments", "UDP complete", or "TCP"
+    /// Input format: "UDP fragments", "UDP complete", or "TCP".
     #[arg(long, default_value_t)]
     input: InputFormat,
-    /// Input header length (the header is discarded)
+    /// Input header length (the header is discarded).
     #[arg(long, default_value_t = 0)]
     header_length: usize,
-    /// ISI to process in MIS mode (if this option is not specified, run in SIS mode)
+    /// ISI to process in MIS mode (if this option is not specified, run in SIS mode).
     #[arg(long)]
     isi: Option<u8>,
-    /// Time interval used to log statistics (in seconds)
+    /// Time interval used to log statistics (in seconds).
     #[arg(long, default_value_t = 100.0)]
     stats_interval: f64,
-    /// Skip checking the GSE total length field
+    /// Skip checking the GSE total length field.
     #[arg(long)]
     skip_total_length: bool,
+    /// Allow GSE packets addressed to the broadcast label (no label).
+    ///
+    /// If this argument is used, all the GSE packets not explicitly allowed via
+    /// CLI arguments are dropped.
+    #[arg(long)]
+    allow_broadcast: bool,
+    /// Allow GSE packets addressed to this 3-byte or 6-byte label.
+    ///
+    /// If this argument is used, all the GSE packets not explicitly allowed via
+    /// CLI arguments are dropped. This argument can be used multiple times to
+    /// allow multiple labels.
+    #[arg(long, value_parser = Label::from_hex)]
+    allow_label: Vec<Label>,
+}
+
+#[derive(Debug, Clone)]
+struct AllowSettings {
+    allow_broadcast: bool,
+    allow_label: Vec<Label>,
+}
+
+impl AllowSettings {
+    fn is_label_allowed(&self, label: &Label) -> bool {
+        if !self.allow_broadcast && self.allow_label.is_empty() {
+            // no 'allow' arguments used; allow everything
+            return true;
+        }
+        if label.is_broadcast() {
+            return self.allow_broadcast;
+        }
+        self.allow_label.iter().any(|allowed| label == allowed)
+    }
+}
+
+impl From<&Args> for AllowSettings {
+    fn from(args: &Args) -> AllowSettings {
+        AllowSettings {
+            allow_broadcast: args.allow_broadcast,
+            allow_label: args.allow_label.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
@@ -127,10 +169,20 @@ struct AppLoop<D> {
     tun: tun_tap::Iface,
     bbframe_recv_errors_fatal: bool,
     stats: Arc<Mutex<Stats>>,
+    allow_settings: AllowSettings,
 }
 
-fn write_pdu_tun(pdu: &PDU, tun: &mut tun_tap::Iface, stats: &mut Stats) {
+fn write_pdu_tun(
+    pdu: &PDU,
+    tun: &mut tun_tap::Iface,
+    stats: &mut Stats,
+    allow_settings: &AllowSettings,
+) {
     stats.gse_packets += 1;
+    if !allow_settings.is_label_allowed(pdu.label()) {
+        stats.gse_packets_dropped_by_label += 1;
+        return;
+    }
     if let Err(err) = tun.send(pdu.data()) {
         log::error!("could not write packet to TUN device: {err}");
         stats.tun_errors += 1;
@@ -158,7 +210,7 @@ impl<D: BBFrameReceiver> AppLoop<D> {
             };
             // the BBFRAME was validated by bbframe_recv, so we can unwrap here
             for pdu in self.gsepacket_defrag.defragment(&bbframe).unwrap() {
-                write_pdu_tun(&pdu, &mut self.tun, &mut stats);
+                write_pdu_tun(&pdu, &mut self.tun, &mut stats, &self.allow_settings);
             }
             // drop stats mutex lock explicitly, for good measure in case code
             // is added below
@@ -178,6 +230,7 @@ struct Stats {
     bbframes: u64,
     bbframe_errors: u64,
     gse_packets: u64,
+    gse_packets_dropped_by_label: u64,
     tun_errors: u64,
 }
 
@@ -186,10 +239,11 @@ fn report_stats(stats: &Mutex<Stats>, interval: Duration) {
         {
             let stats = stats.lock().unwrap();
             log::info!(
-                "BBFRAMES: {}, BBFRAME errors: {}, GSE packets: {}, TUN errors: {}",
+                "BBFRAMES: {}, BBFRAME errors: {}, GSE packets: {}, GSE packets dropped by label: {}, TUN errors: {}",
                 stats.bbframes,
                 stats.bbframe_errors,
                 stats.gse_packets,
+                stats.gse_packets_dropped_by_label,
                 stats.tun_errors
             );
         }
@@ -218,6 +272,7 @@ pub fn main() -> Result<()> {
             let gsepacket_defrag = gsepacket_defragmenter(&args);
             let socket = UdpSocket::bind(args.listen).context("failed to bind to UDP socket")?;
             setup_multicast(&socket, &args.listen)?;
+            let allow_settings = AllowSettings::from(&args);
             match args.input {
                 InputFormat::UdpFragments => {
                     let mut bbframe_recv = BBFrameDefrag::new(socket);
@@ -229,6 +284,7 @@ pub fn main() -> Result<()> {
                         tun,
                         bbframe_recv_errors_fatal: true,
                         stats,
+                        allow_settings,
                     };
                     app.app_loop()?;
                 }
@@ -242,6 +298,7 @@ pub fn main() -> Result<()> {
                         tun,
                         bbframe_recv_errors_fatal: false,
                         stats,
+                        allow_settings,
                     };
                     app.app_loop()?;
                 }
@@ -257,11 +314,12 @@ pub fn main() -> Result<()> {
             // channel.
             let channel_capacity = 64;
             let (tun_tx, tun_rx) = mpsc::sync_channel(channel_capacity);
+            let allow_settings = AllowSettings::from(&args);
             thread::spawn({
                 let stats = Arc::clone(&stats);
                 move || {
                     for pdu in tun_rx.iter() {
-                        write_pdu_tun(&pdu, &mut tun, &mut stats.lock().unwrap());
+                        write_pdu_tun(&pdu, &mut tun, &mut stats.lock().unwrap(), &allow_settings);
                     }
                 }
             });

--- a/src/gseheader.rs
+++ b/src/gseheader.rs
@@ -8,6 +8,7 @@ use super::BitSlice;
 use bitvec::prelude::*;
 use num_enum::TryFromPrimitive;
 use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
 /// GSE Header.
 ///
@@ -235,13 +236,21 @@ impl Display for GSEHeader {
 /// GSE Labels are used for address filtering in the receiver. GSE supports
 /// three kinds of labels: a 6-byte label (as an Ethernet MAC address), a 3-byte
 /// label, and a broadcast label, which is empty.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq)]
 pub struct Label {
     data: [u8; 6],
     size: LabelSize,
 }
 
 impl Label {
+    /// Returns the broadcast (empty) label.
+    pub fn broadcast() -> Label {
+        Label {
+            data: [0; 6],
+            size: LabelSize::Zero,
+        }
+    }
+
     /// Gives a slice containing the label data.
     pub fn as_slice(&self) -> &[u8] {
         &self.data[..self.len()]
@@ -252,11 +261,64 @@ impl Label {
         self.size.len()
     }
 
+    /// Returns `true` if the label is the broadcast (empty) label.
+    pub fn is_broadcast(&self) -> bool {
+        self.is_empty()
+    }
+
     /// Returns `true` if the label has a length of zero bytes.
     ///
     /// This function returns `true` if the label is the broadcast label.
     pub fn is_empty(&self) -> bool {
         matches!(self.size, LabelSize::Zero)
+    }
+
+    /// Parses a 3-byte or 6-byte label given in hex.
+    ///
+    /// The format for the label is either `ab:cd:ef` or `01:23:45:ab:cd:ef`.
+    pub fn from_hex(hex_label: &str) -> Result<Label, LabelParseErr> {
+        let mut data = [0; 6];
+        let mut num_data = 0;
+        for (n, part) in hex_label.split(":").enumerate() {
+            if n >= 6 {
+                // too long
+                return Err(LabelParseErr::WrongHexFormat);
+            }
+            let Ok(x) = u8::from_str_radix(part, 16) else {
+                return Err(LabelParseErr::WrongHexFormat);
+            };
+            data[n] = x;
+            num_data = n;
+        }
+        let size = match num_data + 1 {
+            3 => LabelSize::Size3Bytes,
+            6 => LabelSize::Size6Bytes,
+            _ => return Err(LabelParseErr::WrongHexFormat),
+        };
+        Ok(Label { data, size })
+    }
+}
+
+/// Label parse error.
+#[derive(Error, Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum LabelParseErr {
+    /// Wrong hex format for label.
+    #[error("The hex format for the label is wrong")]
+    WrongHexFormat,
+}
+
+impl PartialEq for Label {
+    fn eq(&self, other: &Label) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl std::hash::Hash for Label {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: std::hash::Hasher,
+    {
+        self.as_slice().hash(state)
     }
 }
 
@@ -517,6 +579,73 @@ mod test {
     #[test]
     fn padding_packet() {
         assert_eq!(GSEHeader::from_slice(&[0; 2], None), None);
+    }
+
+    #[test]
+    fn parse_3byte_label() {
+        assert_eq!(
+            Label::from_hex("01:27:3a").unwrap(),
+            Label {
+                data: [0x01, 0x27, 0x3a, 0x00, 0x00, 0x00],
+                size: LabelSize::Size3Bytes,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_6byte_label() {
+        assert_eq!(
+            Label::from_hex("af:3c:14:59:00:15").unwrap(),
+            Label {
+                data: [0xaf, 0x3c, 0x14, 0x59, 0x00, 0x15],
+                size: LabelSize::Size6Bytes,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_wrong_labels() {
+        assert!(Label::from_hex("foo").is_err());
+        assert!(Label::from_hex("01:00").is_err());
+        assert!(Label::from_hex("01:23:45:67:89:ab:cd").is_err());
+        assert!(Label::from_hex("01:00:02:00").is_err());
+        assert!(Label::from_hex("01273a").is_err());
+        assert!(Label::from_hex("af3c14590015").is_err());
+    }
+
+    #[test]
+    fn broadcast_label() {
+        let label = Label::broadcast();
+        assert!(label.is_broadcast());
+        assert!(label.is_empty());
+    }
+
+    #[test]
+    fn non_broadcast_label() {
+        let label = Label {
+            data: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            size: LabelSize::Size6Bytes,
+        };
+        assert!(!label.is_broadcast());
+        assert!(!label.is_empty());
+    }
+
+    #[test]
+    fn hash_3bytes_does_not_read_extra_bytes() {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+        let a = Label {
+            data: [0x01, 0x02, 0x03, 0x00, 0x00, 0x00],
+            size: LabelSize::Size3Bytes,
+        };
+        let b = Label {
+            data: [0x01, 0x02, 0x03, 0xff, 0xff, 0xff],
+            size: LabelSize::Size3Bytes,
+        };
+        let mut s = DefaultHasher::new();
+        let mut t = DefaultHasher::new();
+        a.hash(&mut s);
+        b.hash(&mut t);
+        assert_eq!(s.finish(), t.finish());
     }
 }
 


### PR DESCRIPTION
This adds CLI arguments to the CLI app that allows defining which GSE PDUs are written to the TUN and which are dropped in terms of their GSE labels.