### PR TITLE
Refactor CLI app to add custom metrics reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-18
+
+### Added
+
+- Custom metrics support in CLI app.
+
 ## [0.8.1] - 2026-05-15
 
 ### Fixed
@@ -161,8 +167,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.8.1...HEAD
-[0.8.0]: https://github.com/daniestevez/dvb-gse/compare/v0.8.0...v0.8.1
+[unreleased]: https://github.com/daniestevez/dvb-gse/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/daniestevez/dvb-gse/compare/v0.8.1...v0.9.0
+[0.8.1]: https://github.com/daniestevez/dvb-gse/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/daniestevez/dvb-gse/compare/v0.7.3...v0.8.0
 [0.7.3]: https://github.com/daniestevez/dvb-gse/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/daniestevez/dvb-gse/compare/v0.7.1...v0.7.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dvb-gse"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 authors = ["Daniel Estevez <daniel@destevez.net>"]
 description = "DVB-GSE (Digital Video Brodcast Generic Stream Encapsulation)"
@@ -36,3 +36,12 @@ tun-tap = { version = "0.1", default-features = false, optional = true }
 hex-literal = "1"
 proptest = "1"
 test-log = "0.2.18"
+
+[[bin]]
+name = "dvb-gse"
+path = "src/main.rs"
+required-features = ["cli"]
+
+[[example]]
+name = "custom-metrics"
+required-features = ["cli"]

--- a/examples/custom-metrics.rs
+++ b/examples/custom-metrics.rs
@@ -1,0 +1,83 @@
+use clap::Parser;
+use dvb_gse::metrics::Metrics;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[command(flatten)]
+    args: dvb_gse::cli::Args,
+    /// Custom argument included in the example
+    #[arg(long)]
+    custom_argument: String,
+}
+
+impl AsRef<dvb_gse::cli::Args> for Args {
+    fn as_ref(&self) -> &dvb_gse::cli::Args {
+        &self.args
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CustomMetrics {
+    bbframe_count: u64,
+    gse_count: u64,
+    custom_argument: String,
+}
+
+impl CustomMetrics {
+    fn new(custom_argument: String) -> CustomMetrics {
+        CustomMetrics {
+            bbframe_count: 0,
+            gse_count: 0,
+            custom_argument,
+        }
+    }
+}
+
+impl Metrics for CustomMetrics {
+    fn bbframe_received(&mut self, _bbframe: &bytes::Bytes) {
+        self.bbframe_count += 1;
+        log::info!(
+            "[{}] BBFRAME received (total {})",
+            self.custom_argument,
+            self.bbframe_count
+        );
+    }
+
+    fn bbframe_error(&mut self, error: &std::io::Error) {
+        log::info!("[{}] BBFRAME error: {error}", self.custom_argument);
+    }
+
+    fn gse_pdu_received(&mut self, _pdu: &dvb_gse::gsepacket::PDU) {
+        self.gse_count += 1;
+        log::info!(
+            "[{}] GSE PDU received (total {})",
+            self.custom_argument,
+            self.gse_count
+        );
+    }
+
+    fn gse_pdu_dropped_label_filtering(&mut self, _pdu: &dvb_gse::gsepacket::PDU) {
+        log::info!(
+            "[{}] GSE PDU dropped by label filtering",
+            self.custom_argument
+        );
+    }
+
+    fn tcp_client_connected(&mut self, _stream: &std::net::TcpStream) {
+        log::info!("[{}] TCP client connected", self.custom_argument);
+    }
+
+    fn tcp_client_finished(&mut self) {
+        log::info!("[{}] TCP client finished", self.custom_argument);
+    }
+
+    fn tun_error(&mut self, error: &std::io::Error, _pdu: &dvb_gse::gsepacket::PDU) {
+        log::info!("[{}] TUN write error: {error}", self.custom_argument);
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let app: dvb_gse::cli::App<Args, CustomMetrics> =
+        dvb_gse::cli::App::new(|args: &Args| Ok(CustomMetrics::new(args.custom_argument.clone())))?;
+    app.run()
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,8 +10,10 @@ use crate::{
     bbframe::{BBFrameDefrag, BBFrameReceiver, BBFrameRecv, BBFrameStream},
     gseheader::Label,
     gsepacket::{GSEPacketDefrag, PDU},
+    metrics::Metrics as MetricsTrait,
 };
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use clap::Parser;
 use std::{
     net::{SocketAddr, TcpListener, UdpSocket},
@@ -21,44 +23,280 @@ use std::{
     time::Duration,
 };
 
+/// dvb-gse CLI application.
+///
+/// This struct contains everything that is needed by the dvb-gse application.
+///
+/// The `AppArgs` type argument defines the type of the CLI arguments of the
+/// application. It can either be [`Args`] if no custom CLI arguments are
+/// needed, or a custom type that extends [`Args`] by implementing
+/// [`clap::Parser`] and `AsRef<Args>`.
+///
+/// The `Metrics` type argument defines the type of the custom metrics. The
+/// default type `()` is used for no metrics. It is possible to provide a type
+/// here that implements the [`Metrics`](MetricsTrait) trait to add custom
+/// metrics to the application.
+pub struct App<AppArgs = Args, Metrics = ()> {
+    args: AppArgs,
+    metrics: AppMetrics<Metrics>,
+}
+
 /// Receive DVB-GSE and send PDUs into a TUN device.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-struct Args {
+pub struct Args {
     /// IP address and port to listen on to receive DVB-S2 BBFRAMEs.
     #[arg(long)]
-    listen: SocketAddr,
+    pub listen: SocketAddr,
     /// TUN interface name.
     #[arg(long)]
-    tun: String,
+    pub tun: String,
     /// Input format: "UDP fragments", "UDP complete", or "TCP".
     #[arg(long, default_value_t)]
-    input: InputFormat,
+    pub input: InputFormat,
     /// Input header length (the header is discarded).
     #[arg(long, default_value_t = 0)]
-    header_length: usize,
+    pub header_length: usize,
     /// ISI to process in MIS mode (if this option is not specified, run in SIS mode).
     #[arg(long)]
-    isi: Option<u8>,
+    pub isi: Option<u8>,
     /// Time interval used to log statistics (in seconds).
     #[arg(long, default_value_t = 100.0)]
-    stats_interval: f64,
+    pub stats_interval: f64,
     /// Skip checking the GSE total length field.
     #[arg(long)]
-    skip_total_length: bool,
+    pub skip_total_length: bool,
     /// Allow GSE packets addressed to the broadcast label (no label).
     ///
     /// If this argument is used, all the GSE packets not explicitly allowed via
     /// CLI arguments are dropped.
     #[arg(long)]
-    allow_broadcast: bool,
+    pub allow_broadcast: bool,
     /// Allow GSE packets addressed to this 3-byte or 6-byte label.
     ///
     /// If this argument is used, all the GSE packets not explicitly allowed via
     /// CLI arguments are dropped. This argument can be used multiple times to
     /// allow multiple labels.
     #[arg(long, value_parser = Label::from_hex)]
-    allow_label: Vec<Label>,
+    pub allow_label: Vec<Label>,
+}
+
+impl AsRef<Args> for Args {
+    fn as_ref(&self) -> &Args {
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AppMetrics<Metrics> {
+    stats: Arc<Mutex<Stats>>,
+    metrics: Metrics,
+}
+
+impl<Metrics: MetricsTrait> MetricsTrait for AppMetrics<Metrics> {
+    fn bbframe_received(&mut self, bbframe: &Bytes) {
+        self.stats.lock().unwrap().bbframes += 1;
+        self.metrics.bbframe_received(bbframe);
+    }
+
+    fn bbframe_error(&mut self, error: &std::io::Error) {
+        self.stats.lock().unwrap().bbframe_errors += 1;
+        self.metrics.bbframe_error(error);
+    }
+
+    fn gse_pdu_received(&mut self, pdu: &PDU) {
+        self.stats.lock().unwrap().gse_pdus += 1;
+        self.metrics.gse_pdu_received(pdu);
+    }
+
+    fn gse_pdu_dropped_label_filtering(&mut self, pdu: &PDU) {
+        self.stats.lock().unwrap().gse_pdus_dropped_by_label += 1;
+        self.metrics.gse_pdu_dropped_label_filtering(pdu);
+    }
+
+    fn tcp_client_connected(&mut self, stream: &std::net::TcpStream) {
+        self.metrics.tcp_client_connected(stream);
+    }
+
+    fn tcp_client_finished(&mut self) {
+        self.metrics.tcp_client_finished();
+    }
+
+    fn tun_error(&mut self, error: &std::io::Error, pdu: &PDU) {
+        self.stats.lock().unwrap().tun_errors += 1;
+        self.metrics.tun_error(error, pdu);
+    }
+}
+
+impl<AppArgs: Parser, Metrics> App<AppArgs, Metrics> {
+    /// Creates a dvb-gse application by parsing arguments and doing some
+    /// initialization.
+    ///
+    /// The [`App::run`] method needs to be called to run the application.
+    ///
+    /// The `build_metrics` closure is used to build a `Metrics` object from the
+    /// parsed CLI arguments.
+    pub fn new<F: FnOnce(&AppArgs) -> Result<Metrics>>(build_metrics: F) -> Result<Self> {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+        let args = AppArgs::parse();
+        let metrics = build_metrics(&args)?;
+        let stats = Arc::new(Mutex::new(Stats::default()));
+        let metrics = AppMetrics { stats, metrics };
+        Ok(App { args, metrics })
+    }
+}
+
+impl<AppArgs: Parser, Metrics: Default> App<AppArgs, Metrics> {
+    /// Creates a dvb-gse application with default metrics by parsing arguments
+    /// and doing some initialization.
+    ///
+    /// The [`App::run`] method needs to be called to run the application.
+    ///
+    /// The `Metrics` object is constructed by calling its [`Default`]
+    /// implementation.
+    pub fn with_default_metrics() -> Result<Self> {
+        Self::new(|_| Ok(Metrics::default()))
+    }
+}
+
+impl<AppArgs: AsRef<Args>, Metrics: MetricsTrait + Clone + Send + 'static> App<AppArgs, Metrics> {
+    /// Runs the dvb-gse application.
+    ///
+    /// This function only returns if there is a fatal error.
+    pub fn run(self) -> Result<()> {
+        let tun = tun_tap::Iface::without_packet_info(&self.args.as_ref().tun, tun_tap::Mode::Tun)
+            .context("failed to open TUN device")?;
+        log::info!("dvb-gse v{} started", env!("CARGO_PKG_VERSION"));
+        let stats_interval = self.args.as_ref().stats_interval;
+        if stats_interval != 0.0 {
+            std::thread::spawn({
+                let stats = Arc::clone(&self.metrics.stats);
+                move || {
+                    report_stats(&stats, Duration::from_secs_f64(stats_interval));
+                }
+            });
+        }
+        match self.args.as_ref().input {
+            InputFormat::UdpFragments | InputFormat::UdpComplete => self.run_udp_input(tun),
+            InputFormat::Tcp => self.run_tcp_input(tun),
+        }
+    }
+
+    fn run_udp_input(self, tun: tun_tap::Iface) -> Result<()> {
+        let gsepacket_defrag = gsepacket_defragmenter(self.args.as_ref());
+        let socket =
+            UdpSocket::bind(self.args.as_ref().listen).context("failed to bind to UDP socket")?;
+        setup_multicast(&socket, &self.args.as_ref().listen)?;
+        let allow_settings = AllowSettings::from(self.args.as_ref());
+        match self.args.as_ref().input {
+            InputFormat::UdpFragments => {
+                let mut bbframe_recv = BBFrameDefrag::new(socket);
+                bbframe_recv.set_isi(self.args.as_ref().isi);
+                bbframe_recv.set_header_bytes(self.args.as_ref().header_length)?;
+                let mut app = AppLoop {
+                    bbframe_recv,
+                    gsepacket_defrag,
+                    tun,
+                    bbframe_recv_errors_fatal: true,
+                    metrics: self.metrics,
+                    allow_settings,
+                };
+                app.app_loop()?;
+            }
+            InputFormat::UdpComplete => {
+                let mut bbframe_recv = BBFrameRecv::new(socket);
+                bbframe_recv.set_isi(self.args.as_ref().isi);
+                bbframe_recv.set_header_bytes(self.args.as_ref().header_length)?;
+                let mut app = AppLoop {
+                    bbframe_recv,
+                    gsepacket_defrag,
+                    tun,
+                    bbframe_recv_errors_fatal: false,
+                    metrics: self.metrics,
+                    allow_settings,
+                };
+                app.app_loop()?;
+            }
+            // This function is only called for UDP input types
+            InputFormat::Tcp => unreachable!(),
+        }
+        Ok(())
+    }
+
+    fn run_tcp_input(mut self, mut tun: tun_tap::Iface) -> Result<()> {
+        let listener =
+            TcpListener::bind(self.args.as_ref().listen).context("failed to bind to TCP socket")?;
+        // For TCP, the application runs each TCP connection in a dedicated
+        // thread. There is another thread that owns the TUN. The TCP
+        // connection threads are connected to the TUN thread by an mpsc
+        // channel.
+        let channel_capacity = 64;
+        let (tun_tx, tun_rx) = mpsc::sync_channel(channel_capacity);
+        let allow_settings = AllowSettings::from(self.args.as_ref());
+        thread::spawn({
+            let mut metrics = self.metrics.clone();
+            move || {
+                for pdu in tun_rx.iter() {
+                    write_pdu_tun(&pdu, &mut tun, &mut metrics, &allow_settings);
+                }
+            }
+        });
+        // use thread scope to pass args by reference
+        thread::scope(|s| {
+            for stream in listener.incoming() {
+                let stream = match stream {
+                    Ok(s) => s,
+                    Err(e) => {
+                        log::error!("connection error {e}");
+                        continue;
+                    }
+                };
+                match stream.peer_addr() {
+                    Ok(addr) => log::info!("TCP client connected from {addr}"),
+                    Err(err) => log::error!(
+                        "TCP client connected (but could not retrieve peer address): {err}"
+                    ),
+                }
+                self.metrics.tcp_client_connected(&stream);
+                s.spawn({
+                    let args = self.args.as_ref();
+                    let tun_tx = tun_tx.clone();
+                    let mut metrics = self.metrics.clone();
+                    move || {
+                        let mut gsepacket_defrag = gsepacket_defragmenter(args);
+                        let mut bbframe_recv = BBFrameStream::new(stream);
+                        bbframe_recv.set_isi(args.isi);
+                        if let Err(err) = bbframe_recv.set_header_bytes(args.header_length) {
+                            eprintln!("could not set header length: {err}");
+                            std::process::exit(1);
+                        }
+                        loop {
+                            let bbframe = bbframe_recv.get_bbframe();
+                            let bbframe = {
+                                match bbframe {
+                                    Ok(b) => {
+                                        metrics.bbframe_received(&b);
+                                        b
+                                    }
+                                    Err(err) => {
+                                        log::error!("failed to receive BBFRAME; terminating connection: {err}");
+                                        metrics.bbframe_error(&err);
+                                        metrics.tcp_client_finished();
+                                        return;
+                                    }
+                                }
+                            };
+                            // the BBFRAME was validated by bbframe_recv, so we can unwrap here
+                            for pdu in gsepacket_defrag.defragment(&bbframe).unwrap() {
+                                tun_tx.send(pdu).unwrap();
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -89,8 +327,9 @@ impl From<&Args> for AllowSettings {
     }
 }
 
+/// Input format for the dvb-gse CLI application.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
-enum InputFormat {
+pub enum InputFormat {
     /// BBFRAME fragments in UDP datagrams.
     #[default]
     UdpFragments,
@@ -163,44 +402,43 @@ fn set_reuseaddr(socket: &UdpSocket) -> Result<()> {
 }
 
 #[derive(Debug)]
-struct AppLoop<D> {
+struct AppLoop<D, Metrics> {
     bbframe_recv: D,
     gsepacket_defrag: GSEPacketDefrag,
     tun: tun_tap::Iface,
     bbframe_recv_errors_fatal: bool,
-    stats: Arc<Mutex<Stats>>,
+    metrics: AppMetrics<Metrics>,
     allow_settings: AllowSettings,
 }
 
-fn write_pdu_tun(
+fn write_pdu_tun<Metrics: MetricsTrait>(
     pdu: &PDU,
     tun: &mut tun_tap::Iface,
-    stats: &mut Stats,
+    metrics: &mut AppMetrics<Metrics>,
     allow_settings: &AllowSettings,
 ) {
-    stats.gse_pdus += 1;
+    metrics.gse_pdu_received(pdu);
     if !allow_settings.is_label_allowed(pdu.label()) {
-        stats.gse_pdus_dropped_by_label += 1;
+        metrics.gse_pdu_dropped_label_filtering(pdu);
         return;
     }
     if let Err(err) = tun.send(pdu.data()) {
         log::error!("could not write packet to TUN device: {err}");
-        stats.tun_errors += 1;
+        metrics.tun_error(&err, pdu);
     }
 }
 
-impl<D: BBFrameReceiver> AppLoop<D> {
+impl<D: BBFrameReceiver, Metrics: MetricsTrait> AppLoop<D, Metrics> {
     fn app_loop(&mut self) -> Result<()> {
         loop {
             let bbframe = self.bbframe_recv.get_bbframe();
-            let mut stats = self.stats.lock().unwrap();
             let bbframe = match bbframe {
                 Ok(b) => {
-                    stats.bbframes += 1;
+                    self.metrics.bbframe_received(&b);
                     b
                 }
                 Err(err) => {
-                    stats.bbframe_errors += 1;
+                    self.metrics.bbframe_error(&err);
                     if self.bbframe_recv_errors_fatal {
                         return Err(err).context("failed to receive BBFRAME");
                     } else {
@@ -210,11 +448,8 @@ impl<D: BBFrameReceiver> AppLoop<D> {
             };
             // the BBFRAME was validated by bbframe_recv, so we can unwrap here
             for pdu in self.gsepacket_defrag.defragment(&bbframe).unwrap() {
-                write_pdu_tun(&pdu, &mut self.tun, &mut stats, &self.allow_settings);
+                write_pdu_tun(&pdu, &mut self.tun, &mut self.metrics, &self.allow_settings);
             }
-            // drop stats mutex lock explicitly, for good measure in case code
-            // is added below
-            drop(stats);
         }
     }
 }
@@ -249,134 +484,4 @@ fn report_stats(stats: &Mutex<Stats>, interval: Duration) {
         }
         std::thread::sleep(interval);
     }
-}
-
-/// Main function of the CLI application.
-pub fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    let args = Args::parse();
-    let mut tun = tun_tap::Iface::without_packet_info(&args.tun, tun_tap::Mode::Tun)
-        .context("failed to open TUN device")?;
-    log::info!("dvb-gse v{} started", env!("CARGO_PKG_VERSION"));
-    let stats = Arc::new(Mutex::new(Stats::default()));
-    if args.stats_interval != 0.0 {
-        std::thread::spawn({
-            let stats = Arc::clone(&stats);
-            move || {
-                report_stats(&stats, Duration::from_secs_f64(args.stats_interval));
-            }
-        });
-    }
-    match args.input {
-        InputFormat::UdpFragments | InputFormat::UdpComplete => {
-            let gsepacket_defrag = gsepacket_defragmenter(&args);
-            let socket = UdpSocket::bind(args.listen).context("failed to bind to UDP socket")?;
-            setup_multicast(&socket, &args.listen)?;
-            let allow_settings = AllowSettings::from(&args);
-            match args.input {
-                InputFormat::UdpFragments => {
-                    let mut bbframe_recv = BBFrameDefrag::new(socket);
-                    bbframe_recv.set_isi(args.isi);
-                    bbframe_recv.set_header_bytes(args.header_length)?;
-                    let mut app = AppLoop {
-                        bbframe_recv,
-                        gsepacket_defrag,
-                        tun,
-                        bbframe_recv_errors_fatal: true,
-                        stats,
-                        allow_settings,
-                    };
-                    app.app_loop()?;
-                }
-                InputFormat::UdpComplete => {
-                    let mut bbframe_recv = BBFrameRecv::new(socket);
-                    bbframe_recv.set_isi(args.isi);
-                    bbframe_recv.set_header_bytes(args.header_length)?;
-                    let mut app = AppLoop {
-                        bbframe_recv,
-                        gsepacket_defrag,
-                        tun,
-                        bbframe_recv_errors_fatal: false,
-                        stats,
-                        allow_settings,
-                    };
-                    app.app_loop()?;
-                }
-                _ => unreachable!(),
-            }
-        }
-        InputFormat::Tcp => {
-            let listener =
-                TcpListener::bind(args.listen).context("failed to bind to TCP socket")?;
-            // For TCP, the application runs each TCP connection in a dedicated
-            // thread. There is another thread that owns the TUN. The TCP
-            // connection threads are connected to the TUN thread by an mpsc
-            // channel.
-            let channel_capacity = 64;
-            let (tun_tx, tun_rx) = mpsc::sync_channel(channel_capacity);
-            let allow_settings = AllowSettings::from(&args);
-            thread::spawn({
-                let stats = Arc::clone(&stats);
-                move || {
-                    for pdu in tun_rx.iter() {
-                        write_pdu_tun(&pdu, &mut tun, &mut stats.lock().unwrap(), &allow_settings);
-                    }
-                }
-            });
-            // use thread scope to pass args by reference
-            thread::scope(|s| {
-                for stream in listener.incoming() {
-                    let stream = match stream {
-                        Ok(s) => s,
-                        Err(e) => {
-                            log::error!("connection error {e}");
-                            continue;
-                        }
-                    };
-                    match stream.peer_addr() {
-                        Ok(addr) => log::info!("TCP client connected from {addr}"),
-                        Err(err) => log::error!(
-                            "TCP client connected (but could not retrieve peer address): {err}"
-                        ),
-                    }
-                    s.spawn({
-                        let args = &args;
-                        let tun_tx = tun_tx.clone();
-                        let stats = &stats;
-                        move || {
-                            let mut gsepacket_defrag = gsepacket_defragmenter(args);
-                            let mut bbframe_recv = BBFrameStream::new(stream);
-                            bbframe_recv.set_isi(args.isi);
-                            if let Err(err) = bbframe_recv.set_header_bytes(args.header_length) {
-                                eprintln!("could not set header length: {err}");
-                                std::process::exit(1);
-                            }
-                            loop {
-                                let bbframe = bbframe_recv.get_bbframe();
-                                let bbframe = {
-                                    let mut stats = stats.lock().unwrap();
-                                    match bbframe {
-                                        Ok(b) => {
-                                            stats.bbframes += 1;
-                                            b
-                                        }
-                                        Err(err) => {
-                                            log::error!("failed to receive BBFRAME; terminating connection: {err}");
-                                            stats.bbframe_errors += 1;
-                                            return;
-                                        }
-                                    }
-                                };
-                                // the BBFRAME was validated by bbframe_recv, so we can unwrap here
-                                for pdu in gsepacket_defrag.defragment(&bbframe).unwrap() {
-                                    tun_tx.send(pdu).unwrap();
-                                }
-                            }
-                        }
-                    });
-                }
-            });
-        }
-    }
-    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,6 @@ pub mod gsepacket;
 
 #[cfg(feature = "cli")]
 pub mod cli;
+
+#[cfg(feature = "cli")]
+pub mod metrics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,4 @@
-#[cfg(feature = "cli")]
 fn main() -> anyhow::Result<()> {
-    dvb_gse::cli::main()
-}
-
-#[cfg(not(feature = "cli"))]
-fn main() -> Result<(), &'static str> {
-    Err("The CLI application needs to be built with the 'cli' flag enabled")
+    let app: dvb_gse::cli::App = dvb_gse::cli::App::with_default_metrics()?;
+    app.run()
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,60 @@
+//! Metrics reporting.
+//!
+//! This module defines a trait that allows users to define custom metrics
+//! reporting.
+
+use crate::gsepacket::PDU;
+use bytes::Bytes;
+
+/// dvb-gse metrics reporting.
+///
+/// This trait is used to implement custom metrics reporting for dvb-gse. The
+/// methods defined by this trait are called when certain events happen in the
+/// dvb-gse processing. By default, all the methods do nothing. Trait
+/// implementors can override some or all of these methods to update and report
+/// metrics.
+pub trait Metrics {
+    /// This function is called when a BBFRAME is successfully received.
+    ///
+    /// The BBFRAME is passed as an argument.
+    fn bbframe_received(&mut self, _bbframe: &Bytes) {}
+
+    /// This function is called when an error happens during BBFRAME reception.
+    ///
+    /// The error is passed as an argument.
+    fn bbframe_error(&mut self, _error: &std::io::Error) {}
+
+    /// This function is called when a GSE PDU is successfully received.
+    ///
+    /// The function is called for all GSE PDUs. Even those which are dropped by
+    /// label filtering.
+    ///
+    /// The GSE PDU is passed as an argument.
+    fn gse_pdu_received(&mut self, _pdu: &PDU) {}
+
+    /// This function is called when a GSE PDU is dropped by label filtering.
+    ///
+    /// The GSE PDU that is dropped is passed as an argument.
+    fn gse_pdu_dropped_label_filtering(&mut self, _pdu: &PDU) {}
+
+    /// This function is called when a worker thread is spawned to handle a TCP
+    /// client.
+    fn tcp_client_connected(&mut self, _stream: &std::net::TcpStream) {}
+
+    /// This function is called when a worker thread that is spawned to handle a
+    /// TCP client terminates.
+    fn tcp_client_finished(&mut self) {}
+
+    /// This function is called when the payload of a GSE PDU cannot be written
+    /// to the TUN device.
+    ///
+    /// The error and the PDU that caused the error are passed as arguments.
+    fn tun_error(&mut self, _error: &std::io::Error, _pdu: &PDU) {}
+}
+
+/// Implementation of [`Metrics`] for `()`.
+///
+/// The type `()` is used when the user does not provide a custom object
+/// implementing metrics. This implementation ignores all the calls to the trait
+/// methods.
+impl Metrics for () {}


### PR DESCRIPTION
This refactors the CLI app by adding a Metrics trait that allows users to build a custom CLI app that adds custom metrics reporting. An example of how to implement the custom app is included.